### PR TITLE
Pass file_type to OpenWithXarray

### DIFF
--- a/feedstock/recipe.py
+++ b/feedstock/recipe.py
@@ -81,7 +81,9 @@ transforms = (
         open_kwargs={"block_size": 0, "client_kwargs": client_kwargs},
         max_concurrency=10,
     )
-    | OpenWithXarray()
+    | OpenWithXarray(
+        file_type=pattern.file_type,
+    )
     | Preprocess()
     | StoreToZarr(
         store_name="aqua-modis.zarr",


### PR DESCRIPTION
The latest deployment following merge of #5 failed with

```
File "/srv/conda/envs/notebook/lib/python3.9/site-packages/pangeo_forge_recipes/openers.py", 
  line 239, in open_with_xarray ds = xr.open_dataset(url_or_file_obj, **kw)
File "/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/backends/api.py", 
  line 523, in open_dataset engine = plugins.guess_engine(filename_or_obj)
File "/srv/conda/envs/notebook/lib/python3.9/site-packages/xarray/backends/plugins.py", 
  line 164, in guess_engine raise ValueError(error_msg)
ValueError: did not find a match in any of xarray's currently installed IO backends ['netcdf4', 'h5netcdf', 'scipy', 'cfgrib', 'pydap', 'rasterio', 'zarr'].
```
which is surprising to me, because this works for me locally:

```python
import gcsfs
import xarray as xr

gcs = gcsfs.GCSFileSystem()

example_cached_file = 'pangeo-forge-prod-cache/000754b9c465f3517086d451191fe387-https_oceandata.sci.gsfc.nasa.gov_ob_getfile_aqua_modis.20120508_20120515.l3m.8d.chl.chlor_a.4km.nc'
with gcs.open(example_cached_file) as f:
    ds = xr.open_dataset(f)
```
anyway, this PR is the most obvious possible fix for that error, so I'll try this.