### PR TITLE
Re-deploy without verifying existing cache

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,7 @@ jobs:
             echo prune=false >> $GITHUB_ENV
           fi
       - name: "Deploy recipes"
-        uses: "pangeo-forge/deploy-recipe-action@main"
+        uses: "pangeo-forge/deploy-recipe-action@storage-cls-args"
         with:
           select_recipe_by_label: "true"
           pangeo_forge_runner_config: >
@@ -60,7 +60,10 @@ jobs:
             },
             "InputCacheStorage": {
                 "fsspec_class": "gcsfs.GCSFileSystem",
-                "root_path": "gs://pangeo-forge-prod-cache"
+                "root_path": "gs://pangeo-forge-prod-cache",
+                "pangeo_forge_target_class_args": {
+                    "verify_existing": false
+                }
             }
             }
         env:

--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@target-root-default#egg=pangeo_forge_recipes
+git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@verify-existing-opt#egg=pangeo_forge_recipes


### PR DESCRIPTION
Uses https://github.com/pangeo-forge/pangeo-forge-recipes/pull/630 to re-deploy the production run without verification of the existing cache. This should permit resuming the (previously stalled) caching stage expediently.