### PR TITLE
Redeploy following manual cache fix

### DIFF
--- a/feedstock/requirements.txt
+++ b/feedstock/requirements.txt
@@ -1,1 +1,5 @@
+# note: this branch is paired with:
+# - https://github.com/pangeo-forge/deploy-recipe-action/tree/storage-cls-args
+# - https://github.com/pangeo-forge/pangeo-forge-runner/pull/106
+# these are referenced in the deploy.yaml workflow and should be reverted as well if/when this is reverted
 git+https://github.com/pangeo-forge/pangeo-forge-recipes.git@verify-existing-opt#egg=pangeo_forge_recipes


### PR DESCRIPTION
I'm not really clear why this job keeps hanging on the cache step without erroring out, presumably it has something to with an expiring network connection with the source file server.

Rather than re-run this caching in-band yet again (only to have it stall again), I've just manually cached the remaining files to the GCS bucket, and will now re-deploy on the assumption that we can finally get passed the caching step on this deployment.

I needed some arbitrary change for a PR to trigger this deployment, so just made these housekeeping comments in the requirements file.